### PR TITLE
Unify list UI with reusable card component

### DIFF
--- a/src/components/DataCardList.tsx
+++ b/src/components/DataCardList.tsx
@@ -1,0 +1,103 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { FiMoreHorizontal, FiEdit2, FiTrash2 } from 'react-icons/fi';
+
+export type DataCardListProps<T> = {
+  items: T[];
+  getId: (item: T) => string;
+  renderItem: (item: T) => React.ReactNode;
+  onEdit?: (item: T) => void;
+  onDelete?: (id: string) => void;
+};
+
+function DataCardList<T>({ items, getId, renderItem, onEdit, onDelete }: DataCardListProps<T>) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setActiveId(null);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const toggleMenu = (id: string) => {
+    setActiveId((prev) => (prev === id ? null : id));
+  };
+
+  return (
+    <div className="d-flex flex-column gap-3">
+      {items.map((item) => {
+        const id = getId(item);
+        return (
+          <div
+            key={id}
+            className="p-3 rounded position-relative shadow-sm"
+            style={{
+              backgroundColor: 'var(--color-white)',
+              border: '1px solid var(--color-green)',
+              color: 'var(--color-dark)',
+            }}
+          >
+            {(onEdit || onDelete) && (
+              <div className="position-absolute" style={{ top: 10, right: 10 }}>
+                <button
+                  className="btn btn-sm border-0"
+                  style={{
+                    backgroundColor: '#f1f1f1',
+                    width: 36,
+                    height: 36,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    borderRadius: '50%',
+                  }}
+                  onClick={() => toggleMenu(id)}
+                >
+                  <FiMoreHorizontal size={18} />
+                </button>
+
+                {activeId === id && (
+                  <div
+                    ref={menuRef}
+                    className="position-absolute bg-white border rounded shadow-sm p-2"
+                    style={{ top: '110%', right: 0, minWidth: 120, zIndex: 1000 }}
+                  >
+                    {onEdit && (
+                      <button
+                        className="dropdown-item text-success d-flex align-items-center gap-2"
+                        onClick={() => {
+                          onEdit(item);
+                          setActiveId(null);
+                        }}
+                      >
+                        <FiEdit2 /> Edit
+                      </button>
+                    )}
+                    {onDelete && (
+                      <button
+                        className="dropdown-item text-danger d-flex align-items-center gap-2"
+                        onClick={() => {
+                          onDelete(id);
+                          setActiveId(null);
+                        }}
+                      >
+                        <FiTrash2 /> Hapus
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {renderItem(item)}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default DataCardList;

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -36,7 +36,7 @@ function DataTable<T extends { id: string }>({
   return (
     <div style={{ overflowX: 'auto' }}>
       <table
-        className="sr-table"
+        className="sr-table shadow-sm"
         style={{
           minWidth: '600px',
           fontSize: '0.9rem',
@@ -44,6 +44,7 @@ function DataTable<T extends { id: string }>({
           borderCollapse: 'collapse',
           borderRadius: '0.5rem',
           overflow: 'hidden',
+          border: '1px solid var(--color-green-light)',
         }}
       >
         <thead>

--- a/src/features/ladies/components/LadiesCardList.tsx
+++ b/src/features/ladies/components/LadiesCardList.tsx
@@ -1,0 +1,53 @@
+import { FiUser, FiSmile, FiMapPin, FiCreditCard, FiCalendar } from 'react-icons/fi';
+import DataCardList from '../../../components/DataCardList';
+
+export type Lady = {
+  id: string;
+  nama_lengkap: string;
+  nama_ladies: string;
+  nama_outlet: string;
+  pin: string;
+  nomor_ktp: string;
+  tanggal_bergabung: string;
+  alamat: string;
+};
+
+type Props = {
+  ladies: Lady[];
+  onEdit: (lady: Lady) => void;
+  onDelete: (id: string) => void;
+};
+
+const LadiesCardList = ({ ladies, onEdit, onDelete }: Props) => {
+  return (
+    <DataCardList
+      items={ladies}
+      getId={(l) => l.id}
+      onEdit={onEdit}
+      onDelete={onDelete}
+      renderItem={(l) => (
+        <>
+          <div className="fw-bold d-flex align-items-center mb-1">
+            <FiUser className="me-2" /> {l.nama_lengkap}
+          </div>
+          <div className="d-flex align-items-center mb-1 text-muted" style={{ fontSize: '0.9rem' }}>
+            <FiSmile className="me-2" /> {l.nama_ladies}
+          </div>
+          <div className="d-flex align-items-center mb-1" style={{ fontSize: '0.9rem' }}>
+            <FiMapPin className="me-2" /> {l.nama_outlet}
+          </div>
+          <div className="d-flex align-items-center mb-1" style={{ fontSize: '0.9rem' }}>
+            <FiCreditCard className="me-2" /> PIN: {l.pin}
+          </div>
+          {l.tanggal_bergabung && (
+            <div className="d-flex align-items-center mb-1" style={{ fontSize: '0.9rem' }}>
+              <FiCalendar className="me-2" /> Bergabung: {l.tanggal_bergabung}
+            </div>
+          )}
+        </>
+      )}
+    />
+  );
+};
+
+export default LadiesCardList;

--- a/src/features/pengawas/components/PengawasCardList.tsx
+++ b/src/features/pengawas/components/PengawasCardList.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
-import { FiEdit2, FiTrash2, FiMoreVertical, FiCreditCard, FiCalendar, FiUserPlus } from 'react-icons/fi';
+import { FiCreditCard, FiCalendar, FiUserPlus } from 'react-icons/fi';
+import DataCardList from '../../../components/DataCardList';
 
-type Pengawas = {
+export type Pengawas = {
   id: string;
   nama_lengkap: string;
   nama_panggilan: string | null;
@@ -18,76 +18,20 @@ type Props = {
 };
 
 const PengawasCardList = ({ pengawas, onEdit, onDelete }: Props) => {
-  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
-
   return (
-    <div className="d-flex flex-column gap-3">
-      {pengawas.map((p) => (
-        <div
-          key={p.id}
-          className="p-3 shadow-sm rounded"
-          style={{
-            backgroundColor: 'var(--color-white)',
-            color: 'var(--color-dark)',
-            border: '1px solid var(--color-green-light)',
-            position: 'relative',
-          }}
-        >
-          <div className="d-flex justify-content-between align-items-start">
-            <div>
-              <div className="fw-bold fs-6">{p.nama_lengkap}</div>
-              {p.nama_panggilan && (
-                <div className="text-muted" style={{ fontSize: '0.85rem' }}>
-                  {p.nama_panggilan}
-                </div>
-              )}
+    <DataCardList
+      items={pengawas}
+      getId={(p) => p.id}
+      onEdit={onEdit}
+      onDelete={onDelete}
+      renderItem={(p) => (
+        <>
+          <div className="fw-bold fs-6">{p.nama_lengkap}</div>
+          {p.nama_panggilan && (
+            <div className="text-muted" style={{ fontSize: '0.85rem' }}>
+              {p.nama_panggilan}
             </div>
-            <div style={{ position: 'relative' }}>
-              <button
-                className="btn btn-sm"
-                style={{ color: 'var(--color-dark)' }}
-                onClick={() =>
-                  setOpenMenuId(openMenuId === p.id ? null : p.id)
-                }
-              >
-                <FiMoreVertical />
-              </button>
-              {openMenuId === p.id && (
-                <div
-                  className="position-absolute"
-                  style={{
-                    top: '100%',
-                    right: 0,
-                    zIndex: 10,
-                    backgroundColor: 'white',
-                    border: '1px solid #ccc',
-                    borderRadius: '0.5rem',
-                    boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
-                  }}
-                >
-                  <button
-                    className="dropdown-item d-flex align-items-center px-3 py-2"
-                    onClick={() => {
-                      onEdit(p);
-                      setOpenMenuId(null);
-                    }}
-                  >
-                    <FiEdit2 className="me-2" /> Edit
-                  </button>
-                  <button
-                    className="dropdown-item d-flex align-items-center px-3 py-2 text-danger"
-                    onClick={() => {
-                      onDelete(p.id);
-                      setOpenMenuId(null);
-                    }}
-                  >
-                    <FiTrash2 className="me-2" /> Hapus
-                  </button>
-                </div>
-              )}
-            </div>
-          </div>
-
+          )}
           <div className="mt-2" style={{ fontSize: '0.9rem' }}>
             {p.nomor_ktp && (
               <div className="d-flex align-items-center mb-1">
@@ -105,9 +49,9 @@ const PengawasCardList = ({ pengawas, onEdit, onDelete }: Props) => {
               </div>
             )}
           </div>
-        </div>
-      ))}
-    </div>
+        </>
+      )}
+    />
   );
 };
 

--- a/src/features/user/components/UserCardList.tsx
+++ b/src/features/user/components/UserCardList.tsx
@@ -1,13 +1,7 @@
-import React, { useState, useRef, useEffect } from 'react';
-import {
-  FiMoreHorizontal,
-  FiEdit2,
-  FiTrash2,
-  FiUser,
-  FiType,
-} from 'react-icons/fi';
+import { FiUser, FiType } from 'react-icons/fi';
+import DataCardList from '../../../components/DataCardList';
 
-type User = {
+export type User = {
   id: string;
   username: string;
   nama: string | null;
@@ -20,96 +14,23 @@ type Props = {
 };
 
 const UserCardList = ({ users, onEdit, onDelete }: Props) => {
-  const [activeMenu, setActiveMenu] = useState<string | null>(null);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setActiveMenu(null);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
-  const toggleMenu = (id: string) => {
-    setActiveMenu((prev) => (prev === id ? null : id));
-  };
-
   return (
-    <>
-      {users.map((u) => (
-        <div
-          key={u.id}
-          className="p-3 mb-3 rounded position-relative shadow-sm"
-          style={{
-            backgroundColor: 'var(--color-white)',
-            border: '1px solid var(--color-green)',
-            color: 'var(--color-dark)',
-          }}
-        >
-          {/* Tombol 3 titik */}
-          <div className="position-absolute" style={{ top: 10, right: 10 }}>
-            <button
-              className="btn btn-sm border-0"
-              style={{
-                backgroundColor: '#f1f1f1',
-                width: 36,
-                height: 36,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                borderRadius: '50%',
-              }}
-              onClick={() => toggleMenu(u.id)}
-            >
-              <FiMoreHorizontal size={18} />
-            </button>
-
-            {activeMenu === u.id && (
-              <div
-                ref={menuRef}
-                className="position-absolute bg-white border rounded shadow-sm p-2"
-                style={{
-                  top: '110%',
-                  right: 0,
-                  minWidth: 120,
-                  zIndex: 1000,
-                }}
-              >
-                <button
-                  className="dropdown-item text-success d-flex align-items-center gap-2"
-                  onClick={() => {
-                    onEdit(u);
-                    setActiveMenu(null);
-                  }}
-                >
-                  <FiEdit2 /> Edit
-                </button>
-                <button
-                  className="dropdown-item text-danger d-flex align-items-center gap-2"
-                  onClick={() => {
-                    onDelete(u.id);
-                    setActiveMenu(null);
-                  }}
-                >
-                  <FiTrash2 /> Hapus
-                </button>
-              </div>
-            )}
-          </div>
-
-          {/* Isi Kartu */}
+    <DataCardList
+      items={users}
+      getId={(u) => u.id}
+      onEdit={onEdit}
+      onDelete={onDelete}
+      renderItem={(u) => (
+        <>
           <div className="mb-2 d-flex align-items-center" style={{ color: 'var(--color-dark)' }}>
             <FiUser className="me-2" /> <strong>Username:</strong>&nbsp;{u.username}
           </div>
           <div className="d-flex align-items-center" style={{ color: 'var(--color-dark)' }}>
             <FiType className="me-2" /> <strong>Nama:</strong>&nbsp;{u.nama || '-'}
           </div>
-        </div>
-      ))}
-    </>
+        </>
+      )}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary
- add reusable `DataCardList` for mobile lists
- use new card list in Ladies, Pengawas and User modules
- add responsive Ladies page with mobile card layout
- style DataTable with light border and shadow

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find type definition file for 'react')*

------
https://chatgpt.com/codex/tasks/task_e_683fb7e8ac548325a71244a6b3806f3e